### PR TITLE
Allows user to provide absolute URLs for upload.

### DIFF
--- a/src/Github/Api.php
+++ b/src/Github/Api.php
@@ -225,8 +225,12 @@ class Api extends Sanity
 		} else {
 			$urlPath = $this->expandUriTemplate($urlPath, $parameters, $this->defaultParameters);
 		}
-
-		$url = rtrim($this->url, '/') . '/' . ltrim($urlPath, '/');
+		
+		//Prepend API URL only if has not been provided. Allows user to provide absolute URLs for upload.
+		if(stripos($urlPath,"https://") === false)
+			$url = rtrim($this->url, '/') . '/' . ltrim($urlPath, '/');
+		else
+			$url = $urlPath;
 
 		if ($content !== NULL && (is_array($content) || is_object($content))) {
 			$headers['Content-Type'] = 'application/json; charset=utf-8';


### PR DESCRIPTION
Prepend API URL only if provided URL is relative. So that "https://uploads.github.com" can be supplied for uploading release assets. User can upload file by doing something like following:

```
function upload_zip($repo_name, $release_id, $file_name, $file_path)
{
	global $api;  //Global instance of API class, better to use it as a member of some wrapper class, just for example here.

	$up_url = 'https://uploads.github.com/repos/alcanttor/'.$repo_name.'/releases/'.$release_id.'/assets?name='.$file_name;

	$up_header = ['Content-Type' => 'application/zip'];

	$response = $api->post($up_url, file_get_contents($file_path), [], $up_header);
		
	if($response->getCode() != 201)
		return false;
	else
		return true;
}
```
