### PR TITLE
CachedClient: Send If-None-Match even with Last-Modified

### DIFF
--- a/src/Github/Http/CachedClient.php
+++ b/src/Github/Http/CachedClient.php
@@ -77,7 +77,8 @@ class CachedClient extends Github\Sanity implements IClient
 			/** @var $cached Response */
 			if ($cached->hasHeader('Last-Modified')) {
 				$request->addHeader('If-Modified-Since', $cached->getHeader('Last-Modified'));
-			} elseif ($cached->hasHeader('ETag')) {
+			}
+			if ($cached->hasHeader('ETag')) {
 				$request->addHeader('If-None-Match', $cached->getHeader('ETag'));
 			}
 		}


### PR DESCRIPTION
For some requests, GitHub may reply with a "304 Not Modified" even when some parts of the request have changed since the date in the "If-Modified-Since" header. The observed instance of this scenario was for adding assets to a release.

GitHub support admits that this behavior is unexpected, but suggests to use If-None-Match in such cases.

There is no apparent downside to sending both `If-Modified-Since` and `If-None-Match` headers, so do so.