### PR TITLE
Api: added setter/getter for header Accept

### DIFF
--- a/src/Github/Api.php
+++ b/src/Github/Api.php
@@ -74,6 +74,26 @@ class Api extends Sanity
 
 
 	/**
+	 * @param  string
+	 * @return self
+	 */
+	public function setDefaultAccept($accept)
+	{
+		$this->defaultAccept = $accept;
+		return $this;
+	}
+
+
+	/**
+	 * @return string
+	 */
+	public function getDefaultAccept()
+	{
+		return $this->defaultAccept;
+	}
+
+
+	/**
 	 * @see createRequest()
 	 * @see request()
 	 *


### PR DESCRIPTION
With Accept header like `application/vnd.github.v3.html+json` some endpoints return HTML body instead of plain text, for example `/releases`